### PR TITLE
Support for Duktape coroutines

### DIFF
--- a/pyduktape.pyx
+++ b/pyduktape.pyx
@@ -7,7 +7,6 @@ import sys
 import threading
 import traceback
 
-
 DUK_TYPE_NONE = 0
 DUK_TYPE_UNDEFINED = 1
 DUK_TYPE_NULL = 2
@@ -87,7 +86,7 @@ cdef extern from 'vendor/duktape.c':
     cdef duk_ret_t duk_pcall(duk_context *ctx, duk_idx_t nargs)
     cdef duk_int_t duk_pcall_method(duk_context *ctx, duk_idx_t nargs)
     cdef duk_bool_t duk_is_object(duk_context *ctx, duk_idx_t index)
-    cdef void duk_push_global_stash(duk_context *ctx)
+    cdef void duk_push_heap_stash(duk_context *ctx)
     cdef void duk_dup(duk_context *ctx, duk_idx_t from_index)
     cdef duk_bool_t duk_has_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index)
     cdef duk_bool_t duk_del_prop_index(duk_context *ctx, duk_idx_t obj_index, duk_uarridx_t arr_index)
@@ -103,6 +102,7 @@ cdef extern from 'vendor/duktape.c':
     cdef void duk_set_finalizer(duk_context *ctx, duk_idx_t index)
     cdef void *duk_get_heapptr(duk_context *ctx, duk_idx_t index)
     cdef void duk_push_this(duk_context *ctx)
+    cdef void duk_push_thread(duk_context *ctx)
 
 
 class DuktapeError(Exception):
@@ -117,10 +117,7 @@ class JSError(Exception):
     pass
 
 
-cdef class DuktapeContext(object):
-    cdef duk_context *ctx
-    cdef object thread_id
-    cdef object js_base_path
+cdef class DuktapeHeap(object):
     # index into the global js stash
     # when a js value is returned to python,
     # a reference is kept in the global stash
@@ -132,36 +129,110 @@ cdef class DuktapeContext(object):
     cdef object registered_proxies
     cdef object registered_proxies_reverse
 
+    cdef duk_context *ctx
+
     def __init__(self):
-        self.thread_id = threading.current_thread().ident
-        self.js_base_path = ''
+        self.ctx = duk_create_heap_default()
+        if self.ctx == NULL:
+            raise DuktapeError('Can\'t allocate context')
+
+        set_python_heap(self.ctx, self)
+
         self.next_ref_index = -1
 
         self.registered_objects = {}
         self.registered_proxies = {}
         self.registered_proxies_reverse = {}
 
-        self.ctx = duk_create_heap_default()
-        if self.ctx == NULL:
-            raise DuktapeError('Can\'t allocate context')
+    def __dealloc__(self):
+        duk_destroy_heap(self.ctx)
 
-        set_python_context(self.ctx, self)
+    cdef new_jsref(self, duk_context *ctx, index):
+        self.next_ref_index += 1
+        assert duk_is_object(ctx, index)
+
+        ref_index = self.next_ref_index
+
+        duk_push_heap_stash(ctx)
+        duk_dup(ctx, index - 1)
+        duk_put_prop_index(ctx, -2, 2*ref_index)
+        duk_push_thread(ctx)
+        duk_put_prop_index(ctx, -2, 2*ref_index+1)
+        duk_pop(ctx)
+
+        return ref_index
+
+    def delete_jsref(self, ref_index):
+        duk_push_heap_stash(self.ctx)
+        if not (duk_has_prop_index(self.ctx, -1, 2*ref_index)
+                and duk_has_prop_index(self.ctx, -1, 2*ref_index+1)):
+            duk_pop(self.ctx)
+            raise DuktapeError('Trying to delete non-existent reference')
+        duk_del_prop_index(self.ctx, -1, 2*ref_index)
+        duk_del_prop_index(self.ctx, -1, 2*ref_index+1)
+        duk_pop(self.ctx)
+
+    cdef void register_object(self, void *proxy_ptr, object py_obj):
+        self.registered_objects[<unsigned long>proxy_ptr] = py_obj
+
+    cdef object get_registered_object(self, void *proxy_ptr):
+        return self.registered_objects[<unsigned long>proxy_ptr]
+
+    cdef int is_registered_object(self, void *proxy_ptr):
+        return <unsigned long>proxy_ptr in self.registered_objects
+
+    cdef void unregister_object(self, void *proxy_ptr):
+        del self.registered_objects[<unsigned long>proxy_ptr]
+
+    cdef void register_proxy(self, void *proxy_ptr, void *target_ptr, object py_obj):
+        self.registered_proxies[<unsigned long>proxy_ptr] = <unsigned long>target_ptr
+        self.registered_proxies_reverse[<unsigned long>target_ptr] = <unsigned long>proxy_ptr
+        self.register_object(target_ptr, py_obj)
+
+    cdef object get_registered_object_from_proxy(self, void *proxy_ptr):
+        return self.registered_objects[self.registered_proxies[<unsigned long>proxy_ptr]]
+
+    cdef int is_registered_proxy(self, void *proxy_ptr):
+        if <unsigned long>proxy_ptr not in self.registered_proxies:
+            return 0
+
+        return self.registered_proxies[<unsigned long>proxy_ptr] in self.registered_objects
+
+    cdef void unregister_proxy_from_target(self, void *target_ptr):
+        proxy_ptr = self.registered_proxies_reverse.pop(<unsigned long>target_ptr)
+        del self.registered_objects[<unsigned long>target_ptr]
+        del self.registered_proxies[proxy_ptr]
+
+cdef push_jsref(duk_context *ctx, ref_index):
+    duk_push_heap_stash(ctx)
+    if duk_get_prop_index(ctx, -1, 2*ref_index) == 0:
+        duk_pop_2(ctx)
+        raise DuktapeError('Invalid reference')
+    duk_swap(ctx, -1, -2)
+    duk_pop(ctx)
+
+
+cdef class DuktapeContext(object):
+    cdef duk_context *ctx
+    cdef object js_base_path
+    cdef DuktapeHeap py_heap
+
+    def __init__(self):
+        self.js_base_path = ''
+
+        self.py_heap = DuktapeHeap()
+        self.ctx = self.py_heap.ctx
 
         self._setup_module_search_function()
 
     cdef void _setup_module_search_function(self):
-        duk_get_global_string(self.ctx, 'Duktape')
-        duk_push_c_function(self.ctx, module_search, 1)
-        duk_put_prop_string(self.ctx, -2, 'modSearch')
-        duk_pop(self.ctx)
+        self.get_global('Duktape').modSearch = self.module_search
 
-    def _check_thread(self):
-        if threading.current_thread().ident != self.thread_id:
-            raise DuktapeThreadError()
+    def module_search(self, module_id, require, exports, module):
+        with open(self.get_file_path(module_id)) as module:
+            return module.read()
 
     def set_globals(self, **kwargs):
-        self._check_thread()
-
         for name, value in kwargs.iteritems():
             self._set_global(name.encode('utf-8'), value)
 
@@ -175,7 +246,7 @@ cdef class DuktapeContext(object):
 
         duk_get_global_string(self.ctx, name.encode('utf-8'))
         try:
-            value = to_python(self, -1)
+            value = to_python(self.ctx, -1)
         finally:
             duk_pop(self.ctx)
 
@@ -215,15 +286,13 @@ cdef class DuktapeContext(object):
         return src_path
 
     def _eval_js(self, eval_function):
-        self._check_thread()
 
         if eval_function() != 0:
-            error = self.get_error()
-            duk_pop(self.ctx)
+            error = get_error(self.ctx)
             result = None
         else:
             error = None
-            result = to_python(self, -1)
+            result = to_python(self.ctx, -1)
         duk_pop(self.ctx)
 
         if error:
@@ -231,186 +300,93 @@ cdef class DuktapeContext(object):
 
         return result
 
-    cdef object get_error(self):
-        if duk_get_prop_string(self.ctx, -1, 'stack') == 0:
-            error = duk_safe_to_string(self.ctx, -2)
-        else:
-            error = to_python(self, -1)
 
-        return error
-
-    def make_jsref(self, duk_idx_t index):
-        self._check_thread()
-
-        assert duk_is_object(self.ctx, index)
-
-        self.next_ref_index += 1
-
-        duk_push_global_stash(self.ctx)
-        duk_dup(self.ctx, index - 1)
-        duk_put_prop_index(self.ctx, -2, self.next_ref_index)
-        duk_pop(self.ctx)
-
-        return JSRef(self, self.next_ref_index)
-
-    cdef void register_object(self, void *proxy_ptr, object py_obj):
-        self.registered_objects[<unsigned long>proxy_ptr] = py_obj
-
-    cdef object get_registered_object(self, void *proxy_ptr):
-        return self.registered_objects[<unsigned long>proxy_ptr]
-
-    cdef int is_registered_object(self, void *proxy_ptr):
-        return <unsigned long>proxy_ptr in self.registered_objects
-
-    cdef void unregister_object(self, void *proxy_ptr):
-        del self.registered_objects[<unsigned long>proxy_ptr]
-
-    cdef void register_proxy(self, void *proxy_ptr, void *target_ptr, object py_obj):
-        self.registered_proxies[<unsigned long>proxy_ptr] = <unsigned long>target_ptr
-        self.registered_proxies_reverse[<unsigned long>target_ptr] = <unsigned long>proxy_ptr
-        self.register_object(target_ptr, py_obj)
-
-    cdef object get_registered_object_from_proxy(self, void *proxy_ptr):
-        return self.registered_objects[self.registered_proxies[<unsigned long>proxy_ptr]]
-
-    cdef int is_registered_proxy(self, void *proxy_ptr):
-        if <unsigned long>proxy_ptr not in self.registered_proxies:
-            return 0
-
-        return self.registered_proxies[<unsigned long>proxy_ptr] in self.registered_objects
-
-    cdef void unregister_proxy_from_target(self, void *target_ptr):
-        proxy_ptr = self.registered_proxies_reverse.pop(<unsigned long>target_ptr)
-        del self.registered_objects[<unsigned long>target_ptr]
-        del self.registered_proxies[proxy_ptr]
-
-    def __del__(self):
-        duk_destroy_heap(self.ctx)
-
-
-cdef void set_python_context(duk_context *ctx, DuktapeContext py_ctx):
-    duk_push_global_stash(ctx)
-    duk_push_pointer(ctx, <void*>py_ctx)
-    duk_put_prop_string(ctx, -2, '__py_ctx')
+cdef void set_python_heap(duk_context *ctx, DuktapeHeap py_heap):
+    duk_push_heap_stash(ctx)
+    duk_push_pointer(ctx, <void*>py_heap)
+    duk_put_prop_string(ctx, -2, '__py_heap')
     duk_pop(ctx)
 
 
-cdef DuktapeContext get_python_context(duk_context *ctx):
-    duk_push_global_stash(ctx)
-    duk_get_prop_string(ctx, -1, '__py_ctx')
-    py_ctx = <DuktapeContext>duk_get_pointer(ctx, -1)
+cdef DuktapeHeap get_python_heap(duk_context *ctx):
+    duk_push_heap_stash(ctx)
+    duk_get_prop_string(ctx, -1, '__py_heap')
+    py_heap_ptr = duk_get_pointer(ctx, -1)
+    py_heap = <DuktapeHeap>py_heap_ptr
     duk_pop_2(ctx)
 
-    assert py_ctx.ctx is ctx
-
-    return py_ctx
+    return py_heap
 
 
-cdef class JSRef(object):
-    cdef DuktapeContext py_ctx
-    cdef int ref_index
-
-    def __init__(self, DuktapeContext py_ctx, int ref_index):
-        py_ctx._check_thread()
-
-        self.py_ctx = py_ctx
-        self.ref_index = ref_index
-
-    def to_js(self):
-        self.py_ctx._check_thread()
-
-        duk_push_global_stash(self.py_ctx.ctx)
-        if duk_get_prop_index(self.py_ctx.ctx, -1, self.ref_index) == 0:
-            duk_pop_2(self.py_ctx.ctx)
-            raise DuktapeError('Invalid reference')
-        duk_swap(self.py_ctx.ctx, -1, -2)
-        duk_pop(self.py_ctx.ctx)
-
-    def __del__(self):
-        duk_push_global_stash(self.py_ctx.ctx)
-        if not duk_has_prop_index(self.py_ctx.ctx, -1, self.ref_index):
-            duk_pop(self.py_ctx.ctx)
-            raise DuktapeError('Trying to delete non-existent reference')
-
-        duk_del_prop_index(self.py_ctx.ctx, -1, self.ref_index)
-        duk_pop(self.py_ctx.ctx)
+cdef object get_error(duk_context *ctx):
+    error = to_python(ctx, -1) 
+    return error
 
 
 cdef class JSProxy(object):
-    cdef JSRef __ref
+    cdef duk_context *ctx
+    cdef int ref_index
     cdef JSProxy __bind_proxy
 
-    def __init__(self, JSRef ref, bind_proxy):
-        ref.py_ctx._check_thread()
-
-        self.__ref = ref
+    def __init__(self, ref_index, bind_proxy):
+        self.ref_index = ref_index
         self.__bind_proxy = bind_proxy
 
+    def __dealloc__(self):
+        py_heap = get_python_heap(self.ctx)
+        py_heap.delete_jsref(self.ref_index)
+
     def __setattr__(self, name, value):
-        self.__ref.py_ctx._check_thread()
+        ctx = self.ctx
 
-        ctx = self.__ref.py_ctx.ctx
-
-        self.__ref.to_js()
+        to_js(ctx, self)
         to_js(ctx, value)
-        duk_put_prop_string(ctx, -2, name)
+        duk_put_prop_string(ctx, -2, name.encode('utf-8'))
         duk_pop(ctx)
 
     def __getattr__(self, name):
-        self.__ref.py_ctx._check_thread()
+        ctx = self.ctx
 
-        ctx = self.__ref.py_ctx.ctx
-
-        self.__ref.to_js()
+        to_js(ctx, self)
         if not duk_get_prop_string(ctx, -1, name.encode('utf-8')):
             duk_pop_2(ctx)
             raise AttributeError('Attribute {} missing'.format(name))
 
         try:
-            res = to_python(self.__ref.py_ctx, -1, self)
+            res = to_python(ctx, -1, self)
         finally:
             duk_pop_2(ctx)
 
         return res
 
     def __getitem__(self, name):
-        self.__ref.py_ctx._check_thread()
-
         if not isinstance(name, (int, long, basestring)):
             raise TypeError('{} is not a valid index'.format(name))
 
         return getattr(self, unicode(name))
 
     def __repr__(self):
-        self.__ref.py_ctx._check_thread()
+        ctx = self.ctx
 
-        ctx = self.__ref.py_ctx.ctx
-
-        self.__ref.to_js()
+        to_js(ctx, self)
         res = duk_safe_to_string(ctx, -1)
         duk_pop(ctx)
 
         return '<JSProxy: {}, bind_proxy={}>'.format(res, self.__bind_proxy.__repr__())
 
     def __call__(self, *args):
-        self.__ref.py_ctx._check_thread()
-
         if self.__bind_proxy is None:
             return self.__call(duk_pcall, args, None)
         else:
             return self.__call(duk_pcall_method, args, self.__bind_proxy)
 
     def new(self, *args):
-        self.__ref.py_ctx._check_thread()
-
         return self.__call(safe_new, args, None)
 
     cdef __call(self, duk_ret_t (*call_type)(duk_context *, duk_idx_t), args, this):
-        self.__ref.py_ctx._check_thread()
+        ctx = self.ctx
 
-        ctx = self.__ref.py_ctx.ctx
-
-        self.__ref.to_js()
+        to_js(ctx, self)
 
         if not duk_is_callable(ctx, -1):
             duk_pop(ctx)
@@ -423,9 +399,9 @@ cdef class JSProxy(object):
             to_js(ctx, arg)
 
         if call_type(ctx, len(args)) == 0:
-            res, error = to_python(self.__ref.py_ctx, -1), None
+            res, error = to_python(ctx, -1), None
         else:
-            res, error = None, self.__ref.py_ctx.get_error()
+            res, error = None, get_error(ctx)
 
         duk_pop(ctx)
 
@@ -435,21 +411,15 @@ cdef class JSProxy(object):
         return res
 
     def __nonzero__(self):
-        self.__ref.py_ctx._check_thread()
-
         return getattr(self, 'length', 1) > 0
 
     def __len__(self):
-        self.__ref.py_ctx._check_thread()
-
         return self.length
 
     def __iter__(self):
-        self.__ref.py_ctx._check_thread()
+        ctx = self.ctx
 
-        ctx = self.__ref.py_ctx.ctx
-
-        self.__ref.to_js()
+        to_js(ctx, self)
         is_array = duk_is_array(ctx, -1)
         is_object = duk_is_object(ctx, -1)
 
@@ -464,15 +434,10 @@ cdef class JSProxy(object):
             while duk_next(ctx, -1, 0) != 0:
                 keys.append(get_python_string(ctx, -1))
                 duk_pop(ctx)
-            duk_pop_2(ctx) # pop enumerator and self.__ref
+            duk_pop_2(ctx) # pop enumerator and self
 
             for key in keys:
                 yield key
-
-    def to_js(self):
-        self.__ref.py_ctx._check_thread()
-
-        self.__ref.to_js()
 
 
 cdef duk_ret_t call_new(duk_context *ctx):
@@ -492,24 +457,8 @@ cdef duk_ret_t safe_new(duk_context *ctx, int nargs):
     return duk_safe_call(ctx, call_new, nargs + 2, 1)
 
 
-cdef duk_ret_t module_search(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
-    module_id = duk_require_string(ctx, -1)
 
-    try:
-        with open(py_ctx.get_file_path(module_id.decode('utf-8'))) as module:
-            source = module.read()
-    except:
-        duk_error(ctx, DUK_ERR_ERROR, 'Could not load module: %s', module_id)
-
-    duk_push_string(ctx, source.encode('utf-8'))
-
-    return 1
-
-
-cdef object to_python(DuktapeContext py_ctx, duk_idx_t index, JSProxy bind_proxy=None):
-    cdef duk_context *ctx = py_ctx.ctx
-
+cdef object to_python(duk_context *ctx, duk_idx_t index, JSProxy bind_proxy=None):
     type_ = duk_get_type(ctx, index)
 
     if type_ == DUK_TYPE_NONE:
@@ -535,12 +484,15 @@ cdef object to_python(DuktapeContext py_ctx, duk_idx_t index, JSProxy bind_proxy
         return get_python_string(ctx, index)
 
     if type_ == DUK_TYPE_OBJECT:
+        py_heap = get_python_heap(ctx)
         value_ptr = duk_get_heapptr(ctx, index)
-        if py_ctx.is_registered_proxy(value_ptr):
-            return py_ctx.get_registered_object_from_proxy(value_ptr)
+        if py_heap.is_registered_proxy(value_ptr):
+            return py_heap.get_registered_object_from_proxy(value_ptr)
         else:
-            return JSProxy(py_ctx.make_jsref(index), bind_proxy)
-
+            ref_index = py_heap.new_jsref(ctx, index)
+            value = JSProxy(ref_index, bind_proxy) 
+            (<JSProxy>value).ctx = ctx
+            return value
     assert False
 
 
@@ -576,7 +528,8 @@ cdef void to_js(duk_context *ctx, object value) except *:
         return
 
     if isinstance(value, JSProxy):
-        value.to_js()
+        ref_index = (<JSProxy>value).ref_index
+        push_jsref(ctx, ref_index)
         return
 
     if callable(value):
@@ -587,7 +540,7 @@ cdef void to_js(duk_context *ctx, object value) except *:
 
 
 cdef void push_py_proxy(duk_context *ctx, object obj) except *:
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
 
     duk_get_global_string(ctx, 'Proxy')
 
@@ -608,30 +561,30 @@ cdef void push_py_proxy(duk_context *ctx, object obj) except *:
     duk_put_prop_string(ctx, -2, 'has')
 
     if safe_new(ctx, 2) != 0:
-        error = py_ctx.get_error()
+        error = get_error(ctx)
         duk_pop(ctx)
         raise DuktapeError(error)
 
     proxy_ptr = duk_get_heapptr(ctx, -1)
-    py_ctx.register_proxy(proxy_ptr, target_ptr, obj)
+    py_heap.register_proxy(proxy_ptr, target_ptr, obj)
 
 
 cdef duk_ret_t py_proxy_finalizer(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
 
     target_ptr = duk_get_heapptr(ctx, -1)
-    py_ctx.unregister_proxy_from_target(target_ptr)
+    py_heap.unregister_proxy_from_target(target_ptr)
 
     return 0
 
 
 cdef duk_ret_t py_proxy_get(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
     n_args = duk_get_top(ctx)
 
-    with wrap_python_exception(py_ctx):
-        target = py_ctx.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
-        key = to_python(py_ctx, 1 - n_args)
+    try:
+        target = py_heap.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
+        key = to_python(ctx, 1 - n_args)
         value = None
 
         if isinstance(target, (list, tuple)):
@@ -654,17 +607,19 @@ cdef duk_ret_t py_proxy_get(duk_context *ctx):
                     value = getattr(target, key, None)
 
         to_js(ctx, value)
+    except:
+        throw_python_exception(ctx)
 
     return 1
 
 
 cdef duk_ret_t py_proxy_has(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
     n_args = duk_get_top(ctx)
 
-    with wrap_python_exception(py_ctx):
-        target = py_ctx.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
-        key = to_python(py_ctx, 1 - n_args)
+    try:
+        target = py_heap.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
+        key = to_python(ctx, 1 - n_args)
 
         if isinstance(target, (list, tuple)):
             try:
@@ -681,18 +636,20 @@ cdef duk_ret_t py_proxy_has(duk_context *ctx):
             res = hasattr(target, key)
 
         to_js(ctx, res)
+    except:
+        throw_python_exception(ctx)
 
     return 1
 
 
 cdef duk_ret_t py_proxy_set(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
     n_args = duk_get_top(ctx)
 
-    with wrap_python_exception(py_ctx):
-        target = py_ctx.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
-        key = to_python(py_ctx, 1 - n_args)
-        value = to_python(py_ctx, 2 - n_args)
+    try:
+        target = py_heap.get_registered_object(duk_get_heapptr(ctx, 0 - n_args))
+        key = to_python(ctx, 1 - n_args)
+        value = to_python(ctx, 2 - n_args)
 
         if isinstance(target, (list, tuple)):
             try:
@@ -704,6 +661,8 @@ cdef duk_ret_t py_proxy_set(duk_context *ctx):
             target[key] = value
         except TypeError:
             setattr(target, key, value)
+    except:
+        throw_python_exception(ctx)
 
     duk_push_boolean(ctx, 1)
 
@@ -711,9 +670,9 @@ cdef duk_ret_t py_proxy_set(duk_context *ctx):
 
 
 cdef duk_ret_t callback_finalizer(duk_context *ctx):
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
     target_ptr = duk_get_heapptr(ctx, -1)
-    py_ctx.unregister_object(target_ptr)
+    py_heap.unregister_object(target_ptr)
 
     return 0
 
@@ -721,45 +680,44 @@ cdef duk_ret_t callback_finalizer(duk_context *ctx):
 cdef void push_callback(duk_context *ctx, object fn) except *:
     assert callable(fn)
 
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
 
     duk_push_c_function(ctx, callback, DUK_VARARGS)
 
     duk_push_c_function(ctx, callback_finalizer, 1)
     duk_set_finalizer(ctx, -2)
 
-    py_ctx.register_object(duk_get_heapptr(ctx, -1), fn)
+    py_heap.register_object(duk_get_heapptr(ctx, -1), fn)
 
 
 cdef duk_ret_t callback(duk_context *ctx):
     if duk_is_constructor_call(ctx):
         duk_error(ctx, DUK_ERR_ERROR, 'can\'t use new on python objects')
 
-    py_ctx = get_python_context(ctx)
+    py_heap = get_python_heap(ctx)
 
     n_args = duk_get_top(ctx)
 
-    with wrap_python_exception(py_ctx):
+    try:
         args = []
         for i in xrange(0, n_args):
-            args.append(to_python(py_ctx, i - n_args))
+            args.append(to_python(ctx, i - n_args))
 
         duk_push_current_function(ctx)
-        python_callback = py_ctx.get_registered_object(duk_get_heapptr(ctx, -1))
+        python_callback = py_heap.get_registered_object(duk_get_heapptr(ctx, -1))
         duk_pop(ctx)
 
         res = python_callback(*args)
 
         to_js(ctx, res)
+    except:
+        throw_python_exception(ctx)
 
     return 1
 
+cdef throw_python_exception(duk_context *ctx):
+    error = traceback.format_exc()
+    error_bytes = error.encode('utf-8')
+    cdef char *error_str = error_bytes
+    duk_error(ctx, DUK_ERR_ERROR, "%s", error_str)
 
-@contextlib.contextmanager
-def wrap_python_exception(DuktapeContext py_ctx):
-    try:
-        yield
-    except:
-        error = traceback.format_exc()
-        error = error.replace('%', '%%')
-        duk_error(py_ctx.ctx, DUK_ERR_ERROR, error.encode('utf-8'))

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -30,24 +30,6 @@ class TestContext(TestCase):
 
         self.assertTrue(ok[0])
 
-    def test_cant_call_from_different_thread(self):
-        ctx = DuktapeContext()
-        proxy = ctx.eval_js('[1, 2]')
-
-        ok = [False]
-
-        def run():
-            try:
-                proxy[0]
-            except DuktapeThreadError:
-                ok[0] = True
-
-        thread = Thread(target=run)
-        thread.start()
-        thread.join()
-
-        self.assertTrue(ok[0])
-
     def test_raise_js_error(self):
         ctx = DuktapeContext()
 


### PR DESCRIPTION
I had to rewrite the context handling code to allow python callbacks to be invoked from Duktape coroutines.
Duktape coroutines share a heap and global object, but each has a distinct context. In the original code, all callbacks were executed inside the context create in the constructor of DuktapeContext(), which led to bugs when using coroutines.
I also removed the threading checks, since the same Duktape context can execute code in different threads, just not at the same time.