### PR TITLE
Enabling DUK_OPT_SEGFAULT_ON_PANIC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extensions = [
       define_macros=[
         ('DUK_OPT_DEBUGGER_SUPPORT', '1'),
         ('DUK_OPT_INTERRUPT_COUNTER', '1'),
+        ('DUK_OPT_SEGFAULT_ON_PANIC', '1'),
       ],
     )
 ]


### PR DESCRIPTION
Quoting: https://usermanual.wiki/Document/Duktape20Programmers20Guide.1419302401/help

> A panic is caused by Duktape assertion code (if included in the build) or by the default fatal error handler. There is no way to induce
a panic from user code. The default panic handler writes an error message to stderr and abort()s the process. You can use the
DUK_OPT_SEGFAULT_ON_PANIC feature option to cause a deliberate segfault instead of an abort(), which may be useful to get
a stack trace from some debugging tools. You can also override the default panic handler entirely with the feature option
DUK_OPT_PANIC_HANDLER.

I'm currently in the process of testing this change